### PR TITLE
Drop unsupported compiler flags

### DIFF
--- a/build-compiler-rt.sh
+++ b/build-compiler-rt.sh
@@ -10,7 +10,7 @@ mkdir -p $BUILD_DIR && cd $BUILD_DIR
 
 COMPILER_RT_INSTALL_PREFIX="$("$OUTPUT_DIR/bin/clang" --print-resource-dir)"
 COMPILER_RT_CMAKE_FLAGS=""
-COMPILER_RT_CFLAGS="-fdebug-default-version=4 -gdwarf-4 -march=armv8.3-a+pauth -mbranch-protection=pauthabi"
+COMPILER_RT_CFLAGS="-fdebug-default-version=4 -gdwarf-4 -march=armv8.3-a+pauth"
 
 if [ -z "$COMPILER_RT_FULL_BUILD" ]; then
   COMPILER_RT_CMAKE_FLAGS="$COMPILER_RT_CMAKE_FLAGS -DCOMPILER_RT_EXCLUDE_ATOMIC_BUILTIN=OFF"

--- a/build-musl.sh
+++ b/build-musl.sh
@@ -8,13 +8,12 @@ BUILD_DIR=".build/musl"
 rm -rf $BUILD_DIR
 mkdir -p "$BUILD_DIR" && cd "$BUILD_DIR"
 
-export CFLAGS="-O0 -fno-ptrauth-function-pointer-type-discrimination -fdebug-default-version=4 -gdwarf-4 -DMUSL_EXPERIMENTAL_PAC=1 -march=armv8.3-a+pauth -mbranch-protection=pauthabi -isystem$OUTPUT_DIR/lib/clang/18/include"
+export CFLAGS="-O0 -fno-ptrauth-function-pointer-type-discrimination -fdebug-default-version=4 -gdwarf-4 -DMUSL_EXPERIMENTAL_PAC=1 -march=armv8.3-a+pauth -isystem$OUTPUT_DIR/lib/clang/$LLVM_MAJOR_VERSION/include"
 
 $MUSL_SOURCE_DIR/configure \
   $CONFIGURE_ARGS \
   --host=$CROSS_TARGET \
   --target=$CROSS_TARGET \
-  -DMUSL_EXPERIMENTAL_PAC=1 \
   --prefix=/ \
   --disable-wrapper \
   --disable-optimize \

--- a/build-runtimes.sh
+++ b/build-runtimes.sh
@@ -8,7 +8,7 @@ BUILD_DIR=".build/runtimes"
 (test -d $BUILD_DIR && rm -rf $BUILD_DIR) || true
 mkdir -p $BUILD_DIR && cd $BUILD_DIR
 
-FLAGS="-fdebug-default-version=4 -gdwarf-4 -march=armv8.3-a+pauth -mbranch-protection=pauthabi"
+FLAGS="-fdebug-default-version=4 -gdwarf-4 -march=armv8.3-a+pauth"
 
 rm -rf "$TARGET_PREFIX/include/c++" || true
 

--- a/config
+++ b/config
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export CROSS_TARGET="aarch64-linux-musl"
+export CROSS_TARGET="aarch64-linux-pauthtest"
 export KERNEL_ARCH=arm64
 export OUTPUT_DIR="$(pwd)/output"
 export CCACHE_DIR="$(pwd)/ccache"
@@ -15,3 +15,4 @@ export TARGET_PREFIX="$OUTPUT_DIR/$CROSS_TARGET/usr"
 export BUILD_HOST=Linux
 export CROSS_HOST=Linux
 
+export LLVM_MAJOR_VERSION=19


### PR DESCRIPTION
Drop unsupported flags:
* remove `-mbranch-protection=pauthabi`, set the environment component of target triple to `-pauthtest` instead. Current toolchain does not seem to accept `pauthabi` as an argument of `-mbranch-protection=`.
* fix the LLVM major version being hardcoded as `18` inside an include path
* dropped `-DMUSL_EXPERIMENTAL_PAC=1` passed as a "top-level" option to `configure` instead of a compiler flag