### PR TITLE
Download kernel sources from cdn.kernel.org

### DIFF
--- a/build-linux-header.sh
+++ b/build-linux-header.sh
@@ -7,8 +7,10 @@ SOURCE_TARBALL=linux-$LINUX_KERNEL_VERSION.tar.xz
 SOURCE_DIR=".build"
 mkdir -p "$SOURCE_DIR"
 
-if [ ! -f "$SOURCE_DIR/$SOURCE_TARBALL" ]; then
-    curl -sSL "https://mirrors.ustc.edu.cn/kernel.org/linux/kernel/v${LINUX_KERNEL_VERSION%%.*}.x/$SOURCE_TARBALL" -o "$SOURCE_DIR/$SOURCE_TARBALL.tmp"
+if [ ! -f "$SOURCE_DIR/$SOURCE_TARBALL" ] && [ -f "/src/$SOURCE_TARBALL" ]; then
+    cp "/src/$SOURCE_TARBALL" "$SOURCE_DIR/$SOURCE_TARBALL"
+elif [ ! -f "$SOURCE_DIR/$SOURCE_TARBALL" ]; then
+    curl -sSL "https://cdn.kernel.org/pub/linux/kernel/v${LINUX_KERNEL_VERSION%%.*}.x/$SOURCE_TARBALL" -o "$SOURCE_DIR/$SOURCE_TARBALL.tmp"
     mv "$SOURCE_DIR/$SOURCE_TARBALL.tmp" "$SOURCE_DIR/$SOURCE_TARBALL"
 fi
 BUILD_DIR=".build/linux-kernel"

--- a/docker.sh
+++ b/docker.sh
@@ -11,6 +11,8 @@ MUSL_BRANCH=dkovalev/pauth-release-19.x
 LLVM_SHA=b7ed52fbdfe68555de5b19b37cdcbbe84637853f
 MUSL_SHA=1268c66ff4bccb1ad10e4bcf7969703e691669b3
 
+LINUX_KERNEL_VERSION=6.1.58
+
 docker="docker"
 #docker="sudo docker"
 
@@ -43,6 +45,10 @@ fetch_sources() {
   mkdir -p "$ROOT/src"
   test -d "$ROOT/src/llvm" || git clone --depth 1 -b "$LLVM_BRANCH" "$llvm_repo" "$ROOT/src/llvm"
   test -d "$ROOT/src/musl" || git clone --depth 1 -b "$MUSL_BRANCH" "$musl_repo" "$ROOT/src/musl"
+
+  local SOURCE_TARBALL=linux-$LINUX_KERNEL_VERSION.tar.xz
+  curl -sSL "https://cdn.kernel.org/pub/linux/kernel/v${LINUX_KERNEL_VERSION%%.*}.x/$SOURCE_TARBALL" \
+       -o "$ROOT/src/$SOURCE_TARBALL"
 
   check_repo_sha "$ROOT/src/llvm" "$LLVM_SHA"
   check_repo_sha "$ROOT/src/musl" "$MUSL_SHA"


### PR DESCRIPTION
Use cdn.kernel.org instead of a hardcoded Chinese mirror. Fix caching .tar.xz archive when building inside Docker.