### PR TITLE
llvm-test-suite.cmake.example: fix optimization level selection

### DIFF
--- a/llvm-test-suite.cmake.example
+++ b/llvm-test-suite.cmake.example
@@ -23,10 +23,17 @@ string(APPEND ldflags " -Wl,--dynamic-linker,/opt/llvm-pauth/aarch64-linux-pauth
 # Improves quality of analysis done by BOLT gadget scanner.
 string(APPEND ldflags " -Wl,--emit-relocs")
 
-set(CMAKE_C_FLAGS   "${allflags} ${cflags}" CACHE STRING "")
-set(CMAKE_CXX_FLAGS "${allflags} ${cflags}" CACHE STRING "")
-set(CMAKE_EXE_LINKER_FLAGS    "${allflags} ${ldflags}" CACHE STRING "")
-set(CMAKE_MODULE_LINKER_FLAGS "${allflags} ${ldflags}" CACHE STRING "")
-set(CMAKE_SHARED_LINKER_FLAGS "${allflags} ${ldflags}" CACHE STRING "")
+set(CMAKE_C_FLAGS             "${allflags} ${cflags}"  CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS           "${allflags} ${cflags}"  CACHE STRING "" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS    "${allflags} ${ldflags}" CACHE STRING "" FORCE)
+set(CMAKE_MODULE_LINKER_FLAGS "${allflags} ${ldflags}" CACHE STRING "" FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS "${allflags} ${ldflags}" CACHE STRING "" FORCE)
+
+# The *_RELEASE options are appended to the command line after the generic ones.
+set(CMAKE_C_FLAGS_RELEASE             "${allflags} ${cflags}"  CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS_RELEASE           "${allflags} ${cflags}"  CACHE STRING "" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE    "${allflags} ${ldflags}" CACHE STRING "" FORCE)
+set(CMAKE_MODULE_LINKER_FLAGS_RELEASE "${allflags} ${ldflags}" CACHE STRING "" FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${allflags} ${ldflags}" CACHE STRING "" FORCE)
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")


### PR DESCRIPTION
When constructing compiler command lines, the arguments in `*_FLAGS_RELEASE` are appended after those in `*_FLAGS` by CMake. Since `-O3 -DNDEBUG` was left intact in `*_FLAGS_RELEASE`, this resulted in `-O3` being used instead of any custom `-O<level>` flag passed via `CUSTOM_FLAGS`.

This commit overrides both set of variables (and passes `FORCE` flag to `set`) to prevent hard-to-spot errors.