### PR TITLE
Update default kernel version to 6.19.12

### DIFF
--- a/scripts/global-vars
+++ b/scripts/global-vars
@@ -31,10 +31,10 @@ fi
 # Linux kernel version to be used to provide user-space headers to libc.
 # Any recent version should work, so this variable is defined here instead
 # of $REPO_ROOT/config.
-LINUX_KERNEL_VERSION=6.1.58
+LINUX_KERNEL_VERSION=6.19.12
 LINUX_KERNEL_TARBALL_BASENAME="linux-$LINUX_KERNEL_VERSION.tar.xz"
 LINUX_KERNEL_TARBALL_URL="https://cdn.kernel.org/pub/linux/kernel/v${LINUX_KERNEL_VERSION%%.*}.x/$LINUX_KERNEL_TARBALL_BASENAME"
-LINUX_KERNEL_SHA256=ce987ed3d2f640b3a2a62a0a8573d538a36dfd3cc31e2d7a239ce5a16c1c21ad
+LINUX_KERNEL_SHA256=ce5c4f1205f9729286b569b037649591555f31ca1e03cc504bd3b70b8e58a8d5
 
 CPU_COUNT="$(nproc)"
 


### PR DESCRIPTION
Linux 6.1 (released December 2022) is too old for current Rust
[libc](https://github.com/rust-lang/libc) requirements, which need at least
support for `USO4/6`. Bump default headers to 6.19.12 (February 2026), the
latest 6.x release before the 7.0 major version.